### PR TITLE
Listen on --host=localhost

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -66,6 +66,7 @@ func (c *cluster) newNode() *node {
 		cockroachBin,
 		"start",
 		"--insecure",
+		"--host=localhost",
 		fmt.Sprintf("--port=%d", port),
 		fmt.Sprintf("--http-port=%d", httpPort),
 		fmt.Sprintf("--store=%s", dir),


### PR DESCRIPTION
The default value can get confused while connected to a VPN or
weirdly-configured router (of which I happen to have one at home).