### PR TITLE
Give n1 a join flag, too

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -73,9 +73,12 @@ func (c *cluster) newNode() *node {
 		fmt.Sprintf("--cache=256MiB"),
 		// fmt.Sprintf("--logtostderr"),
 	}
-	if port != basePort {
-		args = append(args, fmt.Sprintf("--join=localhost:%d", basePort))
-	}
+
+	// NB: always specify the join flag, even for the
+	// first node, to avoid cockroach insisting we use
+	// start-single-node instead, which we don't want
+	// to.
+	args = append(args, fmt.Sprintf("--join=localhost:%d", basePort))
 	attributes, found := c.attrs[id]
 	if found {
 		args = append(args, fmt.Sprintf("--attrs=%s", attributes))

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/petermattis/roachdemo
+
+go 1.15


### PR DESCRIPTION
Newer versions of cockroach force the use of `start-single-node` if no join flag is specified, but here we're intentionally not doing that as we want to keep the default zone configs.

The clusters created in this way will need to be `./cockroach init`'ed manually, but that's fine by me.